### PR TITLE
Add pyinstaller hook

### DIFF
--- a/qt_material/__init__.py
+++ b/qt_material/__init__.py
@@ -3,6 +3,7 @@ import sys
 import logging
 import base64
 from xml.etree import ElementTree
+from pathlib import Path
 
 from qt_material.resources import ResourseGenerator, RESOURCES_PATH
 GUI = True
@@ -351,3 +352,8 @@ class QtStyleTools:
             button = getattr(self.dock_theme, f'pushButton_{color}')
             button.clicked.connect(self.set_color(parent, color))
 
+
+# ----------------------------------------------------------------------
+def get_hook_dirs():
+    package_folder = Path(__file__).parent
+    return [str(package_folder.absolute())]

--- a/qt_material/hook-qt_material.py
+++ b/qt_material/hook-qt_material.py
@@ -1,0 +1,19 @@
+import qt_material
+from pathlib import Path
+
+qt_material_path = Path(qt_material.__file__).parent
+
+fonts_path = qt_material_path / "fonts"
+datas = [(str(fonts_path), "qt_material/fonts")]
+
+themes_path = qt_material_path / "themes"
+datas += [(str(themes_path), "qt_material/themes")]
+
+dock_path = qt_material_path / "dock_theme.ui"
+datas += [(str(dock_path), "qt_material")]
+
+template_path = qt_material_path / "material.css.template"
+datas += [(str(template_path), "qt_material")]
+
+resources_path = qt_material_path / "resources"
+datas += [(str(resources_path), "qt_material/resources")]

--- a/setup.py
+++ b/setup.py
@@ -40,4 +40,10 @@ setup(
         'Programming Language :: Python :: 3.7',
     ],
 
+    entry_points={
+        "pyinstaller40": [
+            "hook-dirs = qt_material:get_hook_dirs"
+        ]
+    },
+
 )


### PR DESCRIPTION
From pyinstaller doc : 
To add a pyinstaller hook, I needed to create a function specifying the folder in which to find the hook, an entry point going to that function, and the hook itself, which has to be named "hook-qt_material.py" (everything else can be renamed if you like).