### PR TITLE
Fix check indicators in QListView/QTreeView/QTableView for Qt6

### DIFF
--- a/qt_material/material.css.template
+++ b/qt_material/material.css.template
@@ -938,6 +938,7 @@ QListView::item {
   min-height: 25px;
   color: {{secondaryTextColor}};
   selection-color: {{secondaryTextColor}}; /* For Windows */
+  border-color: transparent;  /* Fix #34 */
 }
 
 /*  ------------------------------------------------------------------------  */


### PR DESCRIPTION
This PR fix #34.

Currently, the style doesn't apply to the check indicators in QListView/QTreeView/QTableView in Qt6.
Maybe this is a Qt6 bug.
This bug can be fixed by setting `transparent` to the border-color of QListView/QTreeView/QTableView::item subcontrol.