### PR TITLE
fixed displaying TabBar left/right arrows

### DIFF
--- a/qt_material/material.css.template
+++ b/qt_material/material.css.template
@@ -398,12 +398,12 @@ QTabBar QToolButton::down-arrow {
 }
 
 QTabBar QToolButton::right-arrow {
-  image: url(icon:/primary/rightarrow2.svg);
+  image: url(icon:/disabled/rightarrow2.svg);
   height: {{28|density(density_scale)}}px;
 }
 
 QTabBar QToolButton::left-arrow {
-  image: url(icon:/primary/leftarrow2.svg);
+  image: url(icon:/disabled/leftarrow2.svg);
   height: {{28|density(density_scale)}}px;
 }
 


### PR DESCRIPTION
When the TabBar scroll buttons were shown, the arrows were not displayed correctly #62 

With this change, now the arrows are displayed as expected:

When the scroll is at the left (left scroll button disabled):
![image](https://user-images.githubusercontent.com/2742953/210774956-16413bf2-999c-4329-92cf-df44b06e30de.png)

While the scroll in the middle (both scroll buttons active):
![image](https://user-images.githubusercontent.com/2742953/210774795-e2d144bc-5385-43f7-8116-95785114638f.png)

When the scroll at the right (right scroll button disabled):
![image](https://user-images.githubusercontent.com/2742953/210774703-da7ec83e-a2ab-43fb-aa0f-c4e08ce7960a.png)